### PR TITLE
Keyboard shortcut to copy password

### DIFF
--- a/src/directives/copy-paste.directive.ts
+++ b/src/directives/copy-paste.directive.ts
@@ -1,0 +1,35 @@
+import {
+    Directive,
+    EventEmitter,
+    HostListener,
+    Output,
+} from '@angular/core';
+
+@Directive({
+    selector: '[appCopyPaste]',
+})
+export class CopyPasteDirective {
+    @Output() cut = new EventEmitter();
+    @Output() copy = new EventEmitter();
+    @Output() paste = new EventEmitter();
+
+    @HostListener('keydown', ['$event']) onKeyDown($event: KeyboardEvent) {
+        this.getEventEmitter($event)?.emit();
+    }
+
+    private getEventEmitter($event: KeyboardEvent) {
+        if (!$event.ctrlKey || $event.shiftKey || $event.altKey || $event.metaKey || $event.repeat)
+            return null;
+
+        switch ($event.code) {
+            case 'KeyX':
+                return this.cut;
+            case 'KeyC':
+                return this.copy;
+            case 'KeyV':
+                return this.paste;
+            default:
+                return null;
+        }
+    }
+}

--- a/src/popup/app.module.ts
+++ b/src/popup/app.module.ts
@@ -64,6 +64,8 @@ import { StopClickDirective } from 'jslib-angular/directives/stop-click.directiv
 import { StopPropDirective } from 'jslib-angular/directives/stop-prop.directive';
 import { TrueFalseValueDirective } from 'jslib-angular/directives/true-false-value.directive';
 
+import { CopyPasteDirective } from '../directives/copy-paste.directive';
+
 import { ColorPasswordPipe } from 'jslib-angular/pipes/color-password.pipe';
 import { I18nPipe } from 'jslib-angular/pipes/i18n.pipe';
 import { SearchCiphersPipe } from 'jslib-angular/pipes/search-ciphers.pipe';
@@ -194,6 +196,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         CiphersComponent,
         CollectionsComponent,
         ColorPasswordPipe,
+        CopyPasteDirective,
         CurrentTabComponent,
         EnvironmentComponent,
         ExcludedDomainsComponent,

--- a/src/popup/components/cipher-row.component.html
+++ b/src/popup/components/cipher-row.component.html
@@ -1,5 +1,6 @@
 <a (click)="selectCipher(cipher)" (dblclick)="launchCipher(cipher)" href="#" appStopClick
-    title="{{title}} - {{cipher.name}}" class="box-content-row box-content-row-flex">
+    title="{{title}} - {{cipher.name}}" class="box-content-row box-content-row-flex" appCopyPaste
+    (copy)="copyPassword(cipher)">
     <div class="row-main">
         <app-vault-icon [cipher]="cipher"></app-vault-icon>
         <div class="row-main-content">

--- a/src/popup/components/cipher-row.component.ts
+++ b/src/popup/components/cipher-row.component.ts
@@ -3,9 +3,12 @@ import {
     EventEmitter,
     Input,
     Output,
+    ViewChild,
 } from '@angular/core';
 
 import { CipherView } from 'jslib-common/models/view/cipherView';
+
+import { ActionButtonsComponent } from './action-buttons.component';
 
 @Component({
     selector: 'app-cipher-row',
@@ -19,6 +22,8 @@ export class CipherRowComponent {
     @Input() showView = false;
     @Input() title: string;
 
+    @ViewChild(ActionButtonsComponent) actionButtons: ActionButtonsComponent;
+
     selectCipher(c: CipherView) {
         this.onSelected.emit(c);
     }
@@ -29,5 +34,9 @@ export class CipherRowComponent {
 
     viewCipher(c: CipherView) {
         this.onView.emit(c);
+    }
+
+    copyPassword(cipher: CipherView) {
+        this.actionButtons.copy(cipher, cipher.login.password, 'password', 'Password');
     }
 }


### PR DESCRIPTION
Sometimes you want to copy a password in order to paste it into an application where Bitwarden cannot autofill it.

Previously, you had to use your mouse or tab through a lot of buttons and submenus.

Now, you can go to your browser, activate Bitwarden's popup, search for the password, and copy the password using only your keyboard.